### PR TITLE
Correct assignment of queues in network initialize

### DIFF
--- a/communication/src/allocator/zero_copy/allocator.rs
+++ b/communication/src/allocator/zero_copy/allocator.rs
@@ -67,8 +67,8 @@ pub fn new_vector(
         let worker_network = (0 .. threads).map(|_| (0 .. processes-1).map(|p| merge_queue(network_signals[p].clone())));
         let network_worker = (0 .. processes-1).map(|_| (0 .. threads).map(|t| merge_queue(worker_signals[t].clone())));
 
-        let (worker_to_network, worker_from_network_t): (Vec<Vec<_>>, Vec<Vec<_>>) = worker_network.map(|x| x.unzip()).unzip();
-        let (network_to_worker, network_from_worker_t): (Vec<Vec<_>>, Vec<Vec<_>>) = network_worker.map(|x| x.unzip()).unzip();
+        let (worker_to_network, network_from_worker_t): (Vec<Vec<_>>, Vec<Vec<_>>) = worker_network.map(|x| x.unzip()).unzip();
+        let (network_to_worker, worker_from_network_t): (Vec<Vec<_>>, Vec<Vec<_>>) = network_worker.map(|x| x.unzip()).unzip();
 
         let mut worker_from_network_t: Vec<Vec<Option<MergeQueueConsumer>>> = worker_from_network_t.into_iter().map(|x| x.into_iter().map(Some).collect()).collect();
         let mut network_from_worker_t: Vec<Vec<Option<MergeQueueConsumer>>> = network_from_worker_t.into_iter().map(|x| x.into_iter().map(Some).collect()).collect();


### PR DESCRIPTION
In method `new_vector()` in `zerocopy/allocator` we create the communication queues and assign the sending/receiving ends.
The assignment of `network_from_worker_t` and `worker_from_network_t` was inverted.